### PR TITLE
[PLAT-390] Add pagination in queues page and ability to pause/unpause inside queue page

### DIFF
--- a/lib/sidekiq/web/application.rb
+++ b/lib/sidekiq/web/application.rb
@@ -109,7 +109,7 @@ module Sidekiq
         queue.clear
       end
 
-      redirect "#{root_path}queues"
+      redirect "#{root_path}queues/#{route_params[:name]}"
     end
 
     post "/queues/:name/delete" do

--- a/web/views/_poll_link.erb
+++ b/web/views/_poll_link.erb
@@ -1,7 +1,7 @@
-<% if current_path != '' %>
+<!-- <% if current_path != '' %>
   <% if params[:poll] %>
     <a id="live-poll" class="btn btn-primary active" href="<%= root_path + current_path %>"><%= t('StopPolling') %></a>
   <% else %>
     <a id="live-poll" class="btn btn-primary" href="<%= root_path + current_path %>?<%= qparams(poll: true) %>"><%= t('LivePoll') %></a>
   <% end %>
-<% end %>
+<% end %> -->

--- a/web/views/queue.erb
+++ b/web/views/queue.erb
@@ -1,11 +1,39 @@
 <header class="row">
+  <style>
+    .btn-warning {
+      color: #fff !important;
+      background-color: #cc8015 !important;
+      border-color: #eea236 !important;
+      background-image: none !important;
+    }
+
+    .label-warning {
+      background-color: #cc8015 !important;
+    }
+  </style>
   <div class="col-sm-5">
     <h3>
       <%= t('CurrentMessagesInQueue', :queue => h(@name)) %>
-      <% if @queue.paused? %>
+      <% if (@paused = @queue.paused?) %>
         <span class="label label-danger"><%= t('Paused') %></span>
       <% end %>
       <span class="badge badge-secondary"><%= number_with_delimiter(@total_size) %></span>
+      <form action="<%= root_path %>queues/<%= CGI.escape(@queue.name) %>" method="post">
+        <%= csrf_tag %>
+        <% if @queue.is_non_work_hour_only? %>
+          <input class="btn btn-danger btn-xs" type="submit" name="unset_non_work_hour" value="<%= t('StartExecution') %>" data-confirm="<%= t('AreYouSureUnpauseNonWorkHourQueue', :queue => h(@queue.name)) %>"/>
+        <% else %>
+          <input class="btn btn-danger btn-xs" type="submit" name="set_non_work_hour" value="<%= t('PauseTillNonWorkHours') %>" data-confirm="<%= t('AreYouSureNonWorkHourQueue', :queue => h(@queue.name)) %>"/>
+        <% end %>
+        <% unless @queue.is_non_work_hour_only? %>
+          <% if @queue.paused? %>
+            <input class="btn btn-warning btn-xs" type="submit" name="unpause" value="<%= t('Unpause') %>"/>
+          <% else %>
+            <input class="btn btn-warning btn-xs" type="submit" name="pause" value="<%= t('Pause') %>"/>
+          <% end %>
+        <% end %>
+        <input class="btn btn-danger btn-xs" type="submit" name="delete" value="<%= t('Delete') %>" data-confirm="<%= t('AreYouSureDeleteQueue', :queue => h(@queue.name)) %>"/>
+      </form>
     </h3>
   </div>
   <div class="col-sm-4 pull-right flip">

--- a/web/views/queues.erb
+++ b/web/views/queues.erb
@@ -12,6 +12,9 @@
       background-color: #cc8015 !important;
     }
   </style>
+  <% @count = (params['per_page'] || 20).to_i %>
+  <% @current_page = (params['page'] || 1).to_i %>
+  <% @total_size = @queues.size %>
   <table class="queues table table-hover table-bordered table-striped table-white">
     <thead>
       <th><%= t('Queue') %></th>
@@ -19,7 +22,7 @@
       <th><%= t('Latency') %></th>
       <th class="col-md-3"><%= t('Actions') %></th>
     </thead>
-    <% @queues.each do |queue| %>
+    <% @queues.sort_by(&:name).each_slice(@count).to_a[@current_page - 1].each do |queue| %>
       <tr>
         <td>
           <a href="<%= root_path %>queues/<%= CGI.escape(queue.name) %>"><%= h queue.name %></a>
@@ -54,4 +57,5 @@
       </tr>
     <% end %>
   </table>
+  <%= erb :_paging, locals: { url: "#{root_path}queues" } %>
 </div>


### PR DESCRIPTION
**Context:**
Loading of sidekiq queues page has started to timeout.

**Ticket:**
https://apollopde.atlassian.net/browse/PLAT-390

**Solution:**
- Add ability for engineer to directly pause a queue in the queue page itself (without fetching other queues).
- Add pagination in sidekiq queues page (default per_page  = 20)
- (additional safeguard) remove ability to live poll

Preview:
![image](https://github.com/apolloio/sidekiq-apolloio/assets/11026445/510ae5b0-ed13-49d4-9b78-1802453cdcb9)
![image](https://github.com/apolloio/sidekiq-apolloio/assets/11026445/d54348a2-3aab-4f58-b7e5-72d72e8fe210)
